### PR TITLE
Fix /gallery.html not found error when triggering gallery via terminal

### DIFF
--- a/gallery.js
+++ b/gallery.js
@@ -1,4 +1,3 @@
-// Sample gallery items (replace with your own images)
 const galleryItems = [
     {
         image: 'https://cdn.brainrot.best/DSC03575.JPG',
@@ -237,7 +236,7 @@ function initTerminalAccess() {
     terminalAccess.addEventListener('click', () => {
         terminalAccess.classList.add('active');
         setTimeout(() => {
-            window.location.href = 'index.html';
+            window.location.href = 'gallery.html';
         }, 1000);
     });
 }


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Peteryhs/Brainrot-iamsigma.xyz/pull/8?shareId=d4aa8ae0-72fd-4e6e-bfa7-98c0f8a2bcd2).